### PR TITLE
Add check for windows when using ExtraFiles

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"runtime/debug"
 	"strings"
 )
@@ -23,7 +24,9 @@ func RunInTerminalWithColor(cmdName string, args []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.ExtraFiles = []*os.File{w}
+	if runtime.GOOS != "windows" {
+		cmd.ExtraFiles = []*os.File{w}
+	}
 
 	err = cmd.Run()
 	return err


### PR DESCRIPTION
Not sure if you're accepting PRs, but I really wanted to use this on my Windows box.

ExtraFiles is not supported on Windows, so this adds a check to only add it on non-windows systems. Not sure what the use of it is here, but everything seems to work without it.