### PR TITLE
Clarify first install location. Add 'bit update' support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@
 ### using `cURL` (Simplest way to install) 
 
 ```shell script
+export PREFIX=/opt/bit/git && mkdir -p ${PREFIX}  ## optional: override default install location /usr/local/bin
 curl -sf https://gobinaries.com/chriswalz/bit | sh; curl -sf https://gobinaries.com/chriswalz/bit/bitcomplete | sh && echo y | COMP_INSTALL=1 bitcomplete;
 bit;
 ```
+
+Note that bit (and not the shell) is actually completing subcommands, flags and arguments. You have to enter the command first.
 
 ### using `go` (Harder way to install)
 *Caveats: GOPATH and GOBIN need to be set. Verify with `go env`. If they are not set, add this to your .bashrc or .bash_profile etc. AND open new terminal*

--- a/gitextras/.gitignore
+++ b/gitextras/.gitignore
@@ -1,0 +1,1 @@
+git-update.go

--- a/gitextras/Makefile
+++ b/gitextras/Makefile
@@ -1,0 +1,17 @@
+# Makefile to generate git-<action>.go files from corresponding git-<action>.sh files.
+# Makes it easier to modify and test scripts and then incorporate them on a build.
+
+# Every git-*.sh file will generate a git-*.go file with the correct conventions.
+EXTRAS := $(patsubst %.sh, %.go, $(wildcard git-*.sh))
+git-%.go : git-%.sh
+	echo -n "// generated from $<; DO NOT EDIT\npackage gitextras; const Git$* = \`" > $@
+	cat $< >> $@
+	echo "\`" >> $@
+
+.PHONY: all
+# Wrap git-<action>.sh in git-<action>.go as needed.
+all : $(EXTRAS) .gitignore
+
+# Tell git to ignore the generated files.
+.gitignore : $(shell grep -l -e '^// generated' git-*.go)
+	echo $< | tr ' ' '\n' | sort > $@

--- a/gitextras/git-update.sh
+++ b/gitextras/git-update.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+GREEN="$(tput setaf 2)"
+NORMAL="$(tput sgr0)"
+COLOR_TITLE="$NORMAL"
+
+echon() {
+  echo -e "$@\n"  
+}
+
+cechon() {
+    echo -e "${COLOR_TITLE}## $@${NORMAL}\n"
+}
+
+# me, the absolute path of the script
+me=$(realpath --strip ${BASH_SOURCE:-0})
+# here, the abolute path of the directory where the script lives.
+here=$(dirname ${me})
+# verb, the action. git-update.sh -> update. This script will expect to call update().
+verb=$(basename ${me##*-} .sh)
+
+function update() {
+  set -euo pipefail
+  IFS=$'\n\t'
+
+  # I assume there's some way to find the version of bit before downloading it.
+  # I just invented one.
+  remote_version=$(2>/dev/null curl -sSf https://gobinaries.com/chriswalz/bit.version.txt) || true
+  installed_version=$(${here}/bit --version|head -1|awk '{print $3;}')
+
+  # No need to download if you have the latest version.
+  if [[ "${remote_version}" == "${installed_version}" ]] ; then
+      >&2 cechon "${here}/bit already at version '${remote_version}'"
+      exit 0
+  fi
+
+  # Otherwise, create a temporary place to install bit* and check the version again.
+  export PREFIX=/tmp/bit-${verb}/$$
+  mkdir -p ${PREFIX}
+  # Remove the download when done.
+  trap "rm -rf /tmp/bit-${verb}" EXIT
+  
+  # Get the latest.
+  curl -sf https://gobinaries.com/chriswalz/bit | sh
+  curl -sf https://gobinaries.com/chriswalz/bit/bitcomplete | sh
+  new_version=$(${PREFIX}/bit --version|head -1|awk '{print $3;}')
+
+  # Check the version one more time. Punt if you have the latest.
+  if [[ "${new_version}" == "${installed_version}" ]] ; then
+      >&2 cechon "${here}/bit already at version '${installed_version}'"
+  else
+      # New bits! Archive the installed ones with their version id...
+      mv ${here}/bit{,${installed_version}}
+      mv ${here}/bitcomplete{,${installed_version}}
+      # ... and copy the newer versions.
+      mv ${PREFIX}/bit* ${here}
+      echo y | COMP_INSTALL=1 ${here}/bitcomplete
+      >&2 cechon "Installed ${here}/bit* version '${new_version}' in '${here}'"
+  fi
+}
+
+${verb} $*


### PR DESCRIPTION
Chris, Mike Carifio http://mike.carif.io/ @mcarifio here. Ty for bit. Pleased to meet you.

This pull request incorporates two suggestions. First, I think the installation location `PREFIX` doesn't figure prominently enough in the README.md initial installation, so I updated the text a little bit. This probably reflects a personal preference that I like to "partition off" optional software in `/opt`. But I'm not the only one :-).

Next, I wrote a bash script `gitextras/git-update.sh` that will let `bit` update itself to a new version using `bit update`. It basically wraps your "curl approach". It's chief value is convenience. I've even tested it a few times.

Finally, I don't know enough `go` to generate `git-update.go` which seems to wrap shell scripts. So I tried to follow the pattern of the other `git-something.go` sources and wrote a `Makefile` that will wrap up a `git-something.sh` with `git-something.go`. It's a little hacky, but I think it's easier to test scripts in .sh format.

Cherrypick what you like here and drop the rest. Or drop all of it. There's no rush. Soon I'll be mesmerized by the next shiny thing.