### PR TITLE
Added Chocolatey Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ go get github.com/chriswalz/bit@latest;
 bit
 ```
 
+#### using `Chocolatey` (For Windows Users) 
+```shell script
+choco install bit-git
+```
+
 #### using `zinit` 
 ```shell script
 zinit ice lucit wait"0" as"program" from"gh-r" pick"bit"


### PR DESCRIPTION
# Installation via Chocolatey
Chocolatey allows installing bit and git in a single command (if git is not already installed). It is my preferred package manager on Windows. Microsoft has their own package manager now, but it requires an msi installer (currently).

https://chocolatey.org/packages/bit-git/0.9.10

## Maintenance
- I have an AU repo that is currently setup to maintain this package (no changes/extra work for you).
- I can add you as a maintainer in Chocolatey so that you have basic management rights to the package (delist versions, upload versions etc). This would make it easier to take over the package if anything happened to me and the CI went down.

## Questions, Concerns, Etc
- Installs bit Directly to the path and takes care of upgrades/downgrades/uninstalls
- When I ran it after an install, it failed to recognize the current repo as a git repo (might mean changes need to be made to the install script in the package)

## Should Not Be Merged Before Moderators Approve
Before moderator approval, the package will only be installable if the user explicitly sets the version to install. It will also be hidden from searches until at least one version is approved.