### PR TITLE
bit info: sed regex fails on macOS

### DIFF
--- a/gitextras/git-info.go
+++ b/gitextras/git-info.go
@@ -36,7 +36,7 @@ most_recent_commit() {
 
 submodules() {
   # short sha1
-  git submodule status | sed 's/\([^abcdef0-9]\{0,2\}\)\([abcdef0-9]\{7\}\)\([abcdef0-9]\{33\}\)\(.*\)/\1\2\4/'
+  git submodule status | sed 's/\([^a-f\d]\{0,2\}\)\([a-f\d]\{7\}\)\([a-f\d]\{33\}\)\(.*\)/\1\2\4/'
 }
 
 local_branches() {

--- a/gitextras/git-info.go
+++ b/gitextras/git-info.go
@@ -36,7 +36,7 @@ most_recent_commit() {
 
 submodules() {
   # short sha1
-  git submodule status | sed 's/\([^abcdef0-9]\{,2\}\)\([abcdef0-9]\{7\}\)\([abcdef0-9]\{33\}\)\(.*\)/\1\2\4/'
+  git submodule status | sed 's/\([^abcdef0-9]\{0,2\}\)\([abcdef0-9]\{7\}\)\([abcdef0-9]\{33\}\)\(.*\)/\1\2\4/'
 }
 
 local_branches() {


### PR DESCRIPTION
The `bit info` command tries to fetch information about the status of submodules. The regex used fails on macOS when using the default available `sed` command.

```
sed: 1: "s/\([^abcdef0-9]\{,2\}\ ...": RE error: invalid repetition count(s)
```

This pull request updates the regex so that it works on macOS. It has has also been updated to be a bit shorter. The pattern `abcdef` may be written as `a-f` and `0-9` equals to `\d`.

The change has been tested using a new build on macOS and Arch Linux. Both have the same output.