### PR TITLE
Format imports using `gofumports`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 dist/
 exp/
 *.yml

--- a/cmd/bitcomplete.go
+++ b/cmd/bitcomplete.go
@@ -3,15 +3,16 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/c-bata/go-prompt"
 	"github.com/posener/complete/v2"
 	"github.com/posener/complete/v2/predict"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/thoas/go-funk"
-	"os"
-	"strconv"
-	"strings"
 )
 
 func Bitcomplete() {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/c-bata/go-prompt"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func toString(list []*cobra.Command) []string {
@@ -151,7 +152,7 @@ func TestListGHPullRequests(t *testing.T) {
 	prs := ListGHPullRequests()
 	assert.Contains(t, prs[1].Title, expect.Title)
 	assert.Equal(t, prs[1].Number, expect.Number)
-	//assert.Contains(t, prs[1].State, expect.State)
+	// assert.Contains(t, prs[1].State, expect.State)
 }
 
 func BenchmarkAllBitAndGitSubCommands(b *testing.B) {

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // completeCmd represents the complete command

--- a/cmd/gh.go
+++ b/cmd/gh.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/rs/zerolog/log"
-	"github.com/thoas/go-funk"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/thoas/go-funk"
 )
 
 type PullRequest struct {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 	"os/exec"
 	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 func CloudBranchExists() bool {
@@ -13,8 +14,8 @@ func CloudBranchExists() bool {
 	if err != nil {
 		log.Debug().Err(err)
 	}
-	//log.Println("msg:", string(msg))
-	//log.Println("err:", err)
+	// log.Println("msg:", string(msg))
+	// log.Println("err:", err)
 	return !strings.Contains(string(msg), "There is no tracking information for the current branch")
 }
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/chriswalz/bit/gitextras"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
+
+	"github.com/chriswalz/bit/gitextras"
+	"github.com/spf13/cobra"
 )
 
 // infoCmd represents the info command
@@ -25,7 +26,7 @@ var infoCmd = &cobra.Command{
 		fmt.Println("\nCommits | Files")
 		RunInTerminalWithColor("/bin/sh", []string{`-c`, `git log --pretty=format: --name-only | sort | uniq -c | sort -rg | awk 'NR > 1 { print }' | head -15`})
 	},
-	//Args: cobra.MaximumNArgs(1),
+	// Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/c-bata/go-prompt"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 // prCmd represents the pr command
@@ -15,7 +16,7 @@ var prCmd = &cobra.Command{
 	Long: `bit pr
 bit pr`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var suggestionMap = map[string]func() []prompt.Suggest{
+		suggestionMap := map[string]func() []prompt.Suggest{
 			"pr": lazyLoad(GitHubPRSuggestions),
 		}
 		runPr(suggestionMap)

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"log"
+
+	"github.com/spf13/cobra"
 )
 
 // releaseCmd represents the release command

--- a/cmd/rootShell.go
+++ b/cmd/rootShell.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/c-bata/go-prompt"
 	"github.com/spf13/cobra"
@@ -57,7 +58,7 @@ func CreateSuggestionMap(cmd *cobra.Command) (map[string]func() []prompt.Suggest
 	start = time.Now()
 	allBitCmds := AllBitAndGitSubCommands(cmd)
 	log.Debug().Msg((time.Now().Sub(start)).String())
-	//commonCommands := CobraCommandToSuggestions(CommonCommandsList())
+	// commonCommands := CobraCommandToSuggestions(CommonCommandsList())
 	start = time.Now()
 	branchListSuggestions := BranchListSuggestions()
 	log.Debug().Msg((time.Now().Sub(start)).String())
@@ -91,7 +92,6 @@ func CreateSuggestionMap(cmd *cobra.Command) (map[string]func() []prompt.Suggest
 		//"_any": commonCommands,
 	}
 	return completerSuggestionMap, bitCmdMap
-
 }
 
 // Execute adds all child commands to the shell command and sets flags appropriately.

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // saveCmd represents the save command
@@ -18,7 +19,7 @@ var saveCmd = &cobra.Command{
 		}
 		save(msg)
 	},
-	//Args: cobra.MaximumNArgs(1),
+	// Args: cobra.MaximumNArgs(1),
 }
 
 // add comment
@@ -36,7 +37,7 @@ func save(msg string) {
 	}
 
 	if msg == "" {
-		//if ahead of master
+		// if ahead of master
 		if IsAheadOfCurrent() || !CloudBranchExists() {
 			RunInTerminalWithColor("git", []string{"commit", "-a", "--amend", "--no-edit"}) // amend if already ahead
 		} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 // syncCmd represents the sync command
@@ -83,7 +84,7 @@ sync local-branch
 				return
 			}
 			fmt.Println("Cancelling...")
-			//RunInTerminalWithColor("git", []string{"stash", "pop"}) deprecated switch stashing
+			// RunInTerminalWithColor("git", []string{"stash", "pop"}) deprecated switch stashing
 			return
 		}
 
@@ -101,7 +102,7 @@ sync local-branch
 			refreshOnBranch(branch)
 		}
 	},
-	//Args: cobra.MaximumNArgs(1),
+	// Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,16 +2,17 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-	"github.com/tj/go-update"
-	"github.com/tj/go-update/stores/github"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/tj/go-update"
+	"github.com/tj/go-update/stores/github"
 )
 
 // updateCmd represents the update command
@@ -84,7 +85,7 @@ bit update v0.7.4 (note: v is required)`,
 		if err == nil && fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			// Bit path is a symlink
 			fmt.Println("bit is symlinked. If you used homebrew try:\nbrew upgrade bit-git")
-			//path = resolvedSymlink
+			// path = resolvedSymlink
 			return
 		}
 		log.Debug().Msg("bit is not symlinked")
@@ -99,7 +100,6 @@ bit update v0.7.4 (note: v is required)`,
 
 		fmt.Println("Bit is supported through donations. Consider donating here: ❤ https://github.com/sponsors/chriswalz ")
 		fmt.Printf("Updated bit %s to %s in %s\n", currentVersion, release.Version, dst)
-
 	},
 	Args: cobra.MaximumNArgs(1),
 }
@@ -120,7 +120,6 @@ func getLatestOrSpecified(s update.Store, version string) (*update.Release, erro
 // getLatest returns the latest release, error, or nil when there is none.
 func getLatest(s update.Store) (*update.Release, error) {
 	releases, err := s.LatestReleases()
-
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching releases")
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,11 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/c-bata/go-prompt"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-	"github.com/thoas/go-funk"
 	"os"
 	"os/exec"
 	"regexp"
@@ -14,6 +9,12 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/c-bata/go-prompt"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/thoas/go-funk"
 )
 
 func RunInTerminalWithColor(cmdName string, args []string) error {
@@ -72,10 +73,9 @@ func BranchList() []*Branch {
 }
 
 func toStructuredBranchList(rawBranchData string) []*Branch {
-
 	list := strings.Split(strings.TrimSpace(rawBranchData), "\n")
 
-	var m = map[string]*Branch{}
+	m := map[string]*Branch{}
 	var branches []*Branch
 	for _, line := range list {
 		// first character of each should start with ' which all commits have based on expected raw formatting
@@ -257,8 +257,8 @@ func SuggestionPrompt(prefix string, completer func(d prompt.Document) []prompt.
 		prompt.OptionSelectedSuggestionTextColor(theme.SelectedSuggestionTextColor),
 		prompt.OptionDescriptionBGColor(theme.DescriptionBGColor),
 		prompt.OptionDescriptionTextColor(theme.DescriptionTextColor),
-		//prompt.OptionPreviewSuggestionBGColor(prompt.Yellow),
-		//prompt.OptionPreviewSuggestionTextColor(prompt.Yellow),
+		// prompt.OptionPreviewSuggestionBGColor(prompt.Yellow),
+		// prompt.OptionPreviewSuggestionTextColor(prompt.Yellow),
 		prompt.OptionShowCompletionAtStart(),
 		prompt.OptionCompletionOnDown(),
 		prompt.OptionSwitchKeyBindMode(prompt.EmacsKeyBind),
@@ -355,12 +355,12 @@ func FlagSuggestionsForCommand(gitSubCmd string, flagtype string) []prompt.Sugge
 	str = flagMap[gitSubCmd]
 	if str == "" {
 		return []prompt.Suggest{}
-		//str = parseManPage(gitSubCmd)
+		// str = parseManPage(gitSubCmd)
 	}
 
 	list := strings.Split(str, ".\n\n")
 
-	//list := strings.Split(strings.Split(op[1], "CONFIGURATION")[0], "\n\n")
+	// list := strings.Split(strings.Split(op[1], "CONFIGURATION")[0], "\n\n")
 	var suggestions []prompt.Suggest
 	for i := 0; i < len(list)-1; i++ {
 		line := list[i]
@@ -453,9 +453,9 @@ func parseManPage(subCmd string) string {
 	splitA := strings.Split(string(msg), "\n\nOPTIONS")
 	splitB := regexp.MustCompile(`\.\n\n[A-Z]+`).Split(splitA[1], 2)
 	rawFlagSection := splitB[0]
-	//removeTabs := strings.ReplaceAll(rawFlagSection, "\t", "%%%")
-	//removeTabs := strings.ReplaceAll(rawFlagSection, "\n\t", "")
-	//removeTabs = strings.ReplaceAll(removeTabs, "%%%", "\n\n\t")
+	// removeTabs := strings.ReplaceAll(rawFlagSection, "\t", "%%%")
+	// removeTabs := strings.ReplaceAll(rawFlagSection, "\n\t", "")
+	// removeTabs = strings.ReplaceAll(removeTabs, "%%%", "\n\n\t")
 	return rawFlagSection
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.15
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/apex/log v1.9.0 // indirect
+	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
-	github.com/google/go-github/v32 v32.1.0
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gosuri/uilive v0.0.4 // indirect
+	github.com/gosuri/uiprogress v0.0.1 // indirect
+	github.com/hooklift/assert v0.1.0 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete/v2 v2.0.1-alpha.12

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
-github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=


### PR DESCRIPTION
[`gofumports`](https://github.com/mvdan/gofumpt#readme) is drop-in replacement for `goimports` formatting tool.

https://medium.com/@alenkacz/gofmt-goimports-goreturns-why-do-we-need-three-formatters-a3518ee6cc90