### PR TITLE
Add AUR introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,14 @@ zinit ice lucit wait"0" as"program" from"gh-r" pick"bit"
 zinit light "chriswalz/bit"
 ```
 
-
-
 *Note*: On Windows only the interactive prompt completion works not classic tab completion
+
+#### using AUR (For Arch Linux Users)
+For building a stable version from source, use the [`bit` package](https://aur.archlinux.org/packages/bit)
+
+For building the latest git version from source, use the [`bit-git` package](https://aur.archlinux.org/packages/bit-git)
+
+*Note*: These Packages are community-driven and not offically published my the bit maintainer.
 
 Verify installation with:
 


### PR DESCRIPTION
The AUR is a community-based location for PKGBUILDs, Arch's Install scripts.

There are two unofficial PKGBUILDs. The first, `bit`, does uses the [git tree from tag `v1.0.1`](https://github.com/chriswalz/bit/archive/v1.0.1.tar.gz) (will of course updated in future). The second, `bit-git`, clones the github repo and builds that.

I don't added a command for installing it, cause there is not **the** AUR helper. `yay` is maybe the largest, but not officially supported by Arch Linux.