### PR TITLE
Allow environment variables to be passed to git

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -205,6 +206,7 @@ func tagCurrentBranch(version string) error {
 func execCommand(name string, arg ...string) *exec.Cmd {
 	log.Debug().Msg(name + " " + strings.Join(arg, " "))
 	c := exec.Command(name, arg...)
+	c.Env = os.Environ()
 
 	if name == "git" {
 		// exec commands are parsed by bit without getting printed.


### PR DESCRIPTION
This allows environment variables to be forwarded to Git. This includes anything from [here](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables), but also some `curl` variables such as HTTP(S) proxies.