### PR TITLE
Inherits the current process's environment when exec git cmd

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -207,6 +208,8 @@ func execCommand(name string, arg ...string) *exec.Cmd {
 	c := exec.Command(name, arg...)
 
 	if name == "git" {
+		// inherits the current process's environment.
+		c.Env = os.Environ()
 		// exec commands are parsed by bit without getting printed.
 		// parsing git assumes english
 		c.Env = append(c.Env, "LANG=C")


### PR DESCRIPTION
`exec.Command` will not inherit the parent's environment when `cmd.Env` is not nil.