### PR TITLE
reformat gitmoji commit message

### DIFF
--- a/cmd/gitmoji.go
+++ b/cmd/gitmoji.go
@@ -47,8 +47,14 @@ var gitmojiCmd = &cobra.Command{
 			return
 		}
 		emojiAndMsgWithoutEmojiDescription := strings.ReplaceAll(emojiAndMsg, g.(*Gitmoji).Description, g.(*Gitmoji).Emoji)
-		save([]string{"-m " + emojiAndMsgWithoutEmojiDescription})
+		saveWithEmojiInFront(emojiAndMsgWithoutEmojiDescription)
 	},
+}
+
+func saveWithEmojiInFront(emoji string) {
+	RunInTerminalWithColor("git", []string{"status", "-sb", "--untracked-files=no"})
+	resp := AskMultiLine("Please provide a description of your changes")
+	RunInTerminalWithColor("git", append(append([]string{"commit"}, "-am"), emoji+" "+resp))
 }
 
 func init() {
@@ -59,9 +65,9 @@ func GitmojiSuggestions() []complete.Suggestion {
 	var suggestions []complete.Suggestion
 	for _, gitmoji := range gitmojis {
 		suggestions = append(suggestions, complete.Suggestion{
-			Name: `"` + gitmoji.Description,
-			//Text: "\"" + gitmoji.Emoji + " " + gitmoji.Description,
-			//Description: "  " + gitmoji.Emoji + "  " ,
+			Name: gitmoji.Description,
+			// Text: gitmoji.Emoji + " " + gitmoji.Description,
+			// Description: "  " + gitmoji.Emoji + "  " ,
 		})
 	}
 	return suggestions


### PR DESCRIPTION
when committing using gitmoji currently, the message is formatted as follows.
the `title of the commit message` goes to the **next line**. such as,

```bash
👷 
test commit
description
```


I think `the title of the commit message` should be expressed in **one line with the emoji**.
It's because there is a case where developers only see the title of `each title of commit messages`. 
such as `git log --pretty=online`

```bash
 👷 test commit
 description
```


It's not a completed function due to the problem of `go-prompt` https://github.com/c-bata/go-prompt/issues/209 now
,but I think it's better to follow the **general `use case`**.

