### PR TITLE
fix(README): fix typo lucit -> lucid

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ choco install bit-git
 
 #### using `zinit`
 ```shell script
-zinit ice lucit wait"0" as"program" from"gh-r" pick"bit"
+zinit ice lucid wait"0" as"program" from"gh-r" pick"bit"
 zinit light "chriswalz/bit"
 ```
 


### PR DESCRIPTION
I was trying to install bit using zinit and found the installation command had typo..Changed lucit to lucid. Now the command works perfectly.